### PR TITLE
修复fakeNightVision在正常夜视读秒后消失的特性

### DIFF
--- a/src/main/java/fi/dy/masa/tweakeroo/config/Callbacks.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/config/Callbacks.java
@@ -112,7 +112,7 @@ public class Callbacks
         FeatureToggle.TWEAK_PERIODIC_HOLD_USE.getKeybind().setCallback(KeyCallbackAdjustableFeature.createCallback(FeatureToggle.TWEAK_PERIODIC_HOLD_USE));
 
         Configs.Disable.DISABLE_RENDERING_SCAFFOLDING.setValueChangeCallback((cfg) -> mc.worldRenderer.reload());
-        FeatureToggle.TWEAK_FAKE_NIGHT_VISION.setValueChangeCallback(new FakeNightVision(FeatureToggle.TWEAK_FAKE_NIGHT_VISION, mc));
+        FeatureToggle.TWEAK_FAKE_NIGHT_VISION.setValueChangeCallback(new FakeNightVision());
     }
 
     public static class FeatureCallbackHold implements IValueChangeCallback<IConfigBoolean>

--- a/src/main/java/fi/dy/masa/tweakeroo/mixin/minecraft/MixinClientPlayNetworkHandler.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/mixin/minecraft/MixinClientPlayNetworkHandler.java
@@ -114,7 +114,7 @@ public abstract class MixinClientPlayNetworkHandler extends ClientCommonNetworkH
         if(worldNotNull) {
             // game left
         }
-        FakeNightVision.onGameJoined(client);
+        FakeNightVision.onGameJoined();
     }
 
     @Inject(
@@ -122,6 +122,6 @@ public abstract class MixinClientPlayNetworkHandler extends ClientCommonNetworkH
             at = @At("TAIL")
     )
     private void onPlayerRespawnTail(PlayerRespawnS2CPacket packet, CallbackInfo ci) {
-        FakeNightVision.onPlayerRespawned(client);
+        FakeNightVision.onPlayerRespawned();
     }
 }

--- a/src/main/java/fi/dy/masa/tweakeroo/mixin/minecraft/MixinClientPlayerEntity.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/mixin/minecraft/MixinClientPlayerEntity.java
@@ -1,6 +1,27 @@
 package fi.dy.masa.tweakeroo.mixin.minecraft;
 
+import com.mojang.authlib.GameProfile;
+import fi.dy.masa.tweakeroo.config.Configs;
+import fi.dy.masa.tweakeroo.config.FeatureToggle;
+import fi.dy.masa.tweakeroo.tweaks.FakeNightVision;
+import fi.dy.masa.tweakeroo.util.CameraEntity;
+import fi.dy.masa.tweakeroo.util.CameraUtils;
+import fi.dy.masa.tweakeroo.util.DummyMovementInput;
+import fi.dy.masa.tweakeroo.util.InventoryUtils;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.input.Input;
+import net.minecraft.client.network.AbstractClientPlayerEntity;
+import net.minecraft.client.network.ClientPlayerEntity;
+import net.minecraft.client.world.ClientWorld;
+import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.entity.data.TrackedData;
+import net.minecraft.entity.effect.StatusEffect;
+import net.minecraft.entity.effect.StatusEffectInstance;
+import net.minecraft.entity.effect.StatusEffects;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.registry.entry.RegistryEntry;
+import net.minecraft.util.Hand;
 import org.objectweb.asm.Opcodes;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -11,23 +32,6 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.Slice;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-import com.mojang.authlib.GameProfile;
-import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.input.Input;
-import net.minecraft.client.network.AbstractClientPlayerEntity;
-import net.minecraft.client.network.ClientPlayerEntity;
-import net.minecraft.client.world.ClientWorld;
-import net.minecraft.entity.EquipmentSlot;
-import net.minecraft.entity.effect.StatusEffects;
-import net.minecraft.item.ItemStack;
-import net.minecraft.item.Items;
-import net.minecraft.util.Hand;
-import fi.dy.masa.tweakeroo.config.Configs;
-import fi.dy.masa.tweakeroo.config.FeatureToggle;
-import fi.dy.masa.tweakeroo.util.CameraEntity;
-import fi.dy.masa.tweakeroo.util.CameraUtils;
-import fi.dy.masa.tweakeroo.util.DummyMovementInput;
-import fi.dy.masa.tweakeroo.util.InventoryUtils;
 
 @Mixin(ClientPlayerEntity.class)
 public abstract class MixinClientPlayerEntity extends AbstractClientPlayerEntity
@@ -214,6 +218,16 @@ public abstract class MixinClientPlayerEntity extends AbstractClientPlayerEntity
         if (CameraUtils.shouldPreventPlayerInputs())
         {
             ci.cancel();
+        }
+    }
+
+    @Inject(
+            method = "removeStatusEffectInternal",
+            at = @At("TAIL")
+    )
+    private void onRemoveStatusEffectInternal(RegistryEntry<StatusEffect> effect, CallbackInfoReturnable<StatusEffectInstance> cir) {
+        if (effect == StatusEffects.NIGHT_VISION) {
+            FakeNightVision.onEffectCleared();
         }
     }
 }

--- a/src/main/java/fi/dy/masa/tweakeroo/mixin/minecraft/MixinLivingEntity.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/mixin/minecraft/MixinLivingEntity.java
@@ -10,10 +10,7 @@ import net.minecraft.client.option.Perspective;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
-import net.minecraft.entity.effect.StatusEffect;
-import net.minecraft.entity.effect.StatusEffects;
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.util.Hand;
 import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
@@ -22,7 +19,6 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(LivingEntity.class)
 public abstract class MixinLivingEntity extends Entity
@@ -77,21 +73,4 @@ public abstract class MixinLivingEntity extends Entity
             }
         }
     }
-
-    // fake night vision
-/*    @Inject(
-            method = "hasStatusEffect",
-            at = @At("HEAD"),
-            cancellable = true
-    )
-    private void onHasStatusEffect(RegistryEntry<StatusEffect> effect, CallbackInfoReturnable<Boolean> cir) {
-        MinecraftClient mc = MinecraftClient.getInstance();
-        if (FeatureToggle.TWEAK_FAKE_NIGHT_VISION.getBooleanValue()) {
-            LivingEntity self = (LivingEntity) (Object) this;
-            if (effect == StatusEffects.NIGHT_VISION &&
-                self == mc.player) {
-                cir.setReturnValue(true);
-            }
-        }
-    }*/
 }

--- a/src/main/java/fi/dy/masa/tweakeroo/mixin/minecraft/MixinMilkBucketItem.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/mixin/minecraft/MixinMilkBucketItem.java
@@ -23,6 +23,6 @@ public abstract class MixinMilkBucketItem {
     )
     private void onFinishUsing(ItemStack stack, World world, LivingEntity user, CallbackInfoReturnable<ItemStack> cir) {
         // Notify fakeNightVision reapply NightVision when effect cleared.
-        FakeNightVision.onEffectCleared(user);
+        FakeNightVision.onEffectCleared();
     }
 }

--- a/src/main/java/fi/dy/masa/tweakeroo/tweaks/FakeNightVision.kt
+++ b/src/main/java/fi/dy/masa/tweakeroo/tweaks/FakeNightVision.kt
@@ -4,50 +4,37 @@ import fi.dy.masa.malilib.config.IConfigBoolean
 import fi.dy.masa.malilib.interfaces.IValueChangeCallback
 import fi.dy.masa.tweakeroo.config.FeatureToggle
 import net.minecraft.client.MinecraftClient
-import net.minecraft.client.network.ClientPlayerEntity
-import net.minecraft.entity.LivingEntity
 import net.minecraft.entity.effect.StatusEffectInstance
 import net.minecraft.entity.effect.StatusEffects
 
-class FakeNightVision(
-    feature: FeatureToggle,
-    val mc: MinecraftClient
-) : IValueChangeCallback<IConfigBoolean> {
+private val mc: MinecraftClient = MinecraftClient.getInstance()
+
+class FakeNightVision : IValueChangeCallback<IConfigBoolean> {
 
     companion object {
-        var feature: FeatureToggle? = null
 
         @JvmStatic
-        fun onGameJoined(mc: MinecraftClient) {
-            val player = mc.player ?: return
-            reApplyNightVision(player)
+        fun onGameJoined() {
+            reApplyNightVision()
         }
 
         @JvmStatic
-        fun onEffectCleared(entity: LivingEntity) {
-            val player: ClientPlayerEntity = entity as? ClientPlayerEntity ?: return
-            reApplyNightVision(player)
+        fun onEffectCleared() {
+            reApplyNightVision()
         }
 
         @JvmStatic
-        fun onPlayerRespawned(client: MinecraftClient) {
-            val player = client.player ?: return
-            reApplyNightVision(player)
+        fun onPlayerRespawned() {
+            reApplyNightVision()
         }
 
-        private fun reApplyNightVision(player: ClientPlayerEntity) {
-            feature?.run {
-                if (this.booleanValue) {
-                    if (!player.hasStatusEffect(StatusEffects.NIGHT_VISION)) {
-                        player.addStatusEffect(StatusEffectInstance(StatusEffects.NIGHT_VISION, -1))
-                    }
+        private fun reApplyNightVision() {
+            mc.player?.run {
+                if (FeatureToggle.TWEAK_FAKE_NIGHT_VISION.booleanValue) {
+                    addStatusEffect(StatusEffectInstance(StatusEffects.NIGHT_VISION, -1))
                 }
             }
         }
-    }
-
-    init {
-        FakeNightVision.feature = feature
     }
 
     override fun onValueChanged(config: IConfigBoolean) {


### PR DESCRIPTION
1. 清理了冗余代码
2. 修复 在开启客户端夜视（fakeNightVision）时正常夜视消失时不自动开启的特性